### PR TITLE
Preserve original name of renamed sections in the name field

### DIFF
--- a/xbe/__init__.py
+++ b/xbe/__init__.py
@@ -686,7 +686,7 @@ class Xbe:
 			sec_data_start = sec_hdr.raw_addr
 			sec_data_end = sec_data_start + sec_hdr.raw_size
 			sec_data = data[sec_data_start:sec_data_end]
-			self.sections[sec_name] = XbeSection(sec_name, sec_hdr, sec_data)
+			self.sections[sec_name] = XbeSection(sec_name_base, sec_hdr, sec_data)
 
 			log.debug(('Section %d: %s\n' % (i, sec_name)) + sec_hdr.dumps(indent=2))
 			sec_hdr_offset += ctypes.sizeof(XbeSectionHeader)


### PR DESCRIPTION
This is related to https://github.com/mborgerson/pyxbe/pull/12 and only affects the output of XBEs which have duplicated section names.
Previously, the name of the duplicate was changed both in the dictionary and in its name field. This changes makes it so that pyxbe uses the original name for the name field, causing these two to differ, but preserving the original name, which is the desired behavior for a tool I'm currently working on.