### PR TITLE
Implement logo encoding/decoding and extraction

### DIFF
--- a/xbe/__main__.py
+++ b/xbe/__main__.py
@@ -46,6 +46,10 @@ def extract_images(xbe_path, xbe):
 		with open(out_path, 'wb') as f:
 			f.write(bmp)
 
+	bmp = encode_bmp(*decode_logo(xbe.logo))
+	with open(os.path.join(out_dir, xbe_name + '_logo_image.bmp'), 'wb') as f:
+		f.write(bmp)
+
 def xbx_to_bmp(xbx_path):
 	"""
 	Convert a .xbx image file to a standard BMP file


### PR DESCRIPTION
This implements decoding and encoding of the logo format. I tested it by decoding and encoding the logo of a game XBE, putting it into a new XBE with cxbe, and extracting it with pyxbe again. The images looked identical, but it appears that our code compresses better.

Fixes https://github.com/mborgerson/pyxbe/issues/4